### PR TITLE
Update deprecated variable and docs

### DIFF
--- a/cellmincer/preprocess/main.py
+++ b/cellmincer/preprocess/main.py
@@ -343,7 +343,7 @@ class Preprocess:
         # compute active range mask if stim params provided
         active_mask = None
         if self.stim:
-            active_mask = np.zeros(self.n_frames_per_segment * self.n_segments, dtype=np.bool)
+            active_mask = np.zeros(self.n_frames_per_segment * self.n_segments, dtype=bool)
             for i_seg in range(self.stim['segment_start'], self.stim['segment_end']):
                 active_mask[i_seg * self.n_frames_per_segment + self.stim['frame_start']:
                      i_seg * self.n_frames_per_segment + self.stim['frame_end']] = 1
@@ -352,7 +352,7 @@ class Preprocess:
                      (i_seg + 1) * self.n_frames_per_segment - self.trim['trim_right']]
                 for i_seg in range(self.n_segments)])
         elif not self.infer_active_t_range:
-            active_mask = np.ones((movie_txy.shape[0],), dtype=np.bool)
+            active_mask = np.ones((movie_txy.shape[0],), dtype=bool)
 
         logging.info('Extracting features...')
         feature_extractor = OptopatchGlobalFeatureExtractor(

--- a/cellmincer/preprocess/main.py
+++ b/cellmincer/preprocess/main.py
@@ -343,7 +343,7 @@ class Preprocess:
         # compute active range mask if stim params provided
         active_mask = None
         if self.stim:
-            active_mask = np.zeros(self.n_frames_per_segment * self.n_segments, dtype=bool)
+            active_mask = np.zeros(self.n_frames_per_segment * self.n_segments, dtype=np.bool)
             for i_seg in range(self.stim['segment_start'], self.stim['segment_end']):
                 active_mask[i_seg * self.n_frames_per_segment + self.stim['frame_start']:
                      i_seg * self.n_frames_per_segment + self.stim['frame_end']] = 1
@@ -352,7 +352,7 @@ class Preprocess:
                      (i_seg + 1) * self.n_frames_per_segment - self.trim['trim_right']]
                 for i_seg in range(self.n_segments)])
         elif not self.infer_active_t_range:
-            active_mask = np.ones((movie_txy.shape[0],), dtype=bool)
+            active_mask = np.ones((movie_txy.shape[0],), dtype=np.bool)
 
         logging.info('Extracting features...')
         feature_extractor = OptopatchGlobalFeatureExtractor(

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -26,6 +26,6 @@ Install with ``pip`` from Git repository:
 
 .. code-block:: console
 
-   (cellmincer) $ pip install git+https://github.com/broadinstitute/CellMincer.git
+   (cellmincer) $ python -m pip install git+https://github.com/broadinstitute/CellMincer.git
 
 Because CellMincer uses GPU computing for both training on and denoising voltage imaging, you may wish to confirm that your machine has GPUs with appropriate drivers installed and is CUDA-enabled (e.g. check that ``torch.cuda.is_available()`` returns ``True``).


### PR DESCRIPTION
Replace `np.bool` with `bool` per numpy version update

(edit) Reverting above change. In numpy 2.0 release,
> Introduce [numpy.bool](https://numpy.org/devdocs/reference/arrays.scalars.html#numpy.bool) as the new canonical name for NumPy’s boolean dtype...

Replace local installation command with `python -m pip` to explicitly target active conda environment