### PR TITLE
Release v0.1.3: Hotfix for cellmincer.util.features

### DIFF
--- a/cellmincer/util/features.py
+++ b/cellmincer/util/features.py
@@ -3,6 +3,7 @@ import torch
 import logging
 from dataclasses import dataclass, field
 from typing import List, Optional
+from skimage.filters import threshold_otsu
 from scipy.signal import find_peaks
 
 
@@ -302,7 +303,7 @@ class OptopatchGlobalFeatureExtractor:
             threshold = (m_bins[peaks[0]] + m_bins[peaks[1]]) / 2
         logging.info(f'threshold: {threshold}')
 
-        active_mask_t = self._get_continuous_1d_mask(mask_t > threshold)
+        active_mask_t = OptopatchGlobalFeatureExtractor._get_continuous_1d_mask(mask_t > threshold)
         return active_mask_t
 
     @staticmethod


### PR DESCRIPTION
Applies a hotfix and releases version `v0.1.3` of the Docker image.
Fixes #16 

`self._get_continuous_1d_mask` -> OptopatchGlobalFeatureExtractor._get_continuous_1d_mask`

Adds import for `threshold_otsu` from `skimage.filters`